### PR TITLE
Updated to latest version of do/7.x-1.x

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -142,7 +142,9 @@ example:
     // Ignore some cids in 'cache_bootstrap'.
     'cache_bootstrap' => array(
       'module_implements',
-      'variables'
+      'variables',
+      'schema:runtime:*',
+      'theme_registry:runtime:*',
     ),
     // Ignore all cids in the 'cache' bin starting with 'i18n:string:'
     'cache' => array(

--- a/README.txt
+++ b/README.txt
@@ -284,6 +284,14 @@ minimal collisions.
 
 $conf['memcache_key_hash_algorithm'] = 'sha1';
 
+You can also tune the maximum key length BUT BE AWARE this doesn't affect
+memcached's server-side limitations -- this value is primarily exposed to allow
+you to further shrink the length of keys to optimize network performance.
+Specifying a length larger than 250 will almost certainly lead to problems
+unless you know what you're doing.
+
+$conf['memcache_key_max_length'] = 250;
+
 Visit http://www.php.net/manual/en/function.hash-algos.php to learn more about
 which hash algorithms are available.
 

--- a/dmemcache.inc
+++ b/dmemcache.inc
@@ -618,12 +618,17 @@ function dmemcache_key($key, $bin = 'cache') {
   }
   $full_key = urlencode($prefix . $bin . '-' . $key);
 
-  // Memcache only supports key lengths up to 250 bytes.  If we have generated
-  // a longer key, we shrink it to an acceptible length with a configurable
-  // hashing algorithm. Sha1 was selected as the default as it performs
-  // quickly with minimal collisions.
-  if (strlen($full_key) > 250) {
-    $full_key = urlencode(hash(variable_get('memcache_key_hash_algorithm', 'sha1'), $prefix . $bin . '-' . $key));
+  // Memcache truncates keys longer than 250 characters[*]. This could lead to
+  // cache collisions, so we hash keys that are longer than this while still
+  // retaining as much of the key bin and name as possible to aid in debugging.
+  // The hashing algorithm used is configurable, with sha1 selected by default
+  // as it performs quickly with minimal collisions. You can enforce shorter
+  // keys by setting memcache_key_max_length in settings.php.
+  // [*]https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L47
+  $maxlen = variable_get('memcache_key_max_length', 250);
+  if (strlen($full_key) > $maxlen) {
+    $full_key = urlencode($prefix . $bin) . '-' . hash(variable_get('memcache_key_hash_algorithm', 'sha1'), $key);
+    $full_key .= '-' . substr(urlencode($key), 0, ($maxlen - 1) - strlen($full_key) - 1);
   }
 
   return $full_key;

--- a/memcache.inc
+++ b/memcache.inc
@@ -103,7 +103,7 @@ class MemCacheDrupal implements DrupalCacheInterface {
         if (variable_get('memcache_stampede_protection', FALSE)) {
           // The process that acquires the lock will get a cache miss, all
           // others will get a cache hit.
-          if ($this->lockInit() && lock_acquire("memcache_$cid:$this->bin", variable_get('memcache_stampede_semaphore', 15))) {
+          if ($this->lockInit() && $this->stampedeProtected($cid) && lock_acquire("memcache_$cid:$this->bin", variable_get('memcache_stampede_semaphore', 15))) {
             $cache = FALSE;
           }
         }
@@ -144,7 +144,7 @@ class MemCacheDrupal implements DrupalCacheInterface {
     // On cache misses, attempt to avoid stampedes when the
     // memcache_stampede_protection variable is enabled.
     if (!$cache) {
-      if (variable_get('memcache_stampede_protection', FALSE) && $this->lockInit() && !lock_acquire("memcache_$cid:$this->bin", variable_get('memcache_stampede_semaphore', 15))) {
+      if (variable_get('memcache_stampede_protection', FALSE) && $this->lockInit() && $this->stampedeProtected($cid) && !lock_acquire("memcache_$cid:$this->bin", variable_get('memcache_stampede_semaphore', 15))) {
         // Prevent any single request from waiting more than three times due to
         // stampede protection. By default this is a maximum total wait of 15
         // seconds. This accounts for two possibilities - a cache and lock miss
@@ -474,6 +474,64 @@ class MemCacheDrupal implements DrupalCacheInterface {
     // enough to load the lock system.
     if (!function_exists('lock_acquire')) {
       drupal_bootstrap(DRUPAL_BOOTSTRAP_VARIABLES, FALSE);
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Determines whether stampede protection is enabled for a given bin/cid.
+   *
+   * Memcache stampede protection is primarily designed to benefit the following
+   * caching pattern: a miss on a cache_get for a specific cid is immediately
+   * followed by a cache_set for that cid. In cases where this pattern is not
+   * followed, stampede protection can be disabled to avoid long hanging locks.
+   * For example, a cache miss in Drupal core's module_implements() won't
+   * execute a cache_set until drupal_page_footer() calls
+   * module_implements_write_cache() which can occur much later in page
+   * generation.
+   *
+   * @param string $cid
+   *   The cache id of the data to retrieve.
+   *
+   * @return bool
+   *   Returns TRUE if stampede protection is enabled for that particular cache
+   *   bin/cid, otherwise FALSE.
+   */
+  protected function stampedeProtected($cid) {
+    $ignore_settings = variable_get('memcache_stampede_protection_ignore', array(
+      // Disable stampede protection for specific cids in 'cache_bootstrap'.
+      'cache_bootstrap' => array(
+        // The module_implements cache is written after finishing the request.
+        'module_implements',
+        // Variables have their own lock protection.
+        'variables'
+      ),
+      // Disable stampede protection for cid prefix in 'cache'.
+      'cache' => array(
+        // I18n uses a class destructor to write the cache.
+        'i18n:string:*',
+      ),
+    ));
+
+    // Support ignoring an entire bin.
+    if (in_array($this->bin, $ignore_settings)) {
+      return FALSE;
+    }
+
+    // Support ignoring by cids.
+    if (isset($ignore_settings[$this->bin])) {
+      // Support ignoring specific cids.
+      if (in_array($cid, $ignore_settings[$this->bin])) {
+        return FALSE;
+      }
+      // Support ignoring cids starting with a suffix.
+      foreach ($ignore_settings[$this->bin] as $ignore) {
+        $split = explode('*', $ignore);
+        if (count($split) > 1 && strpos($cid, $split[0]) === 0) {
+          return FALSE;
+        }
+      }
     }
 
     return TRUE;

--- a/memcache.inc
+++ b/memcache.inc
@@ -32,7 +32,10 @@ class MemCacheDrupal implements DrupalCacheInterface {
     // If page_cache_without_database is enabled, we have to manually load the
     // $conf array out of cache_bootstrap.
     static $variables_loaded = FALSE;
-    if (!empty($GLOBALS['conf']['page_cache_without_database']) && !$variables_loaded) {
+    // NOTE: We don't call drupal_get_bootstrap_phase() because this would
+    // break all 7.x Drupal installations prior to 7.33. For more information
+    // see https://www.drupal.org/node/667098.
+    if (drupal_bootstrap(NULL, FALSE) < DRUPAL_BOOTSTRAP_VARIABLES && !$variables_loaded) {
       global $conf;
       $variables_loaded = TRUE;
       // Try loading variables from cache. If that fails, we have to bootstrap

--- a/memcache.inc
+++ b/memcache.inc
@@ -505,13 +505,20 @@ class MemCacheDrupal implements DrupalCacheInterface {
         // The module_implements cache is written after finishing the request.
         'module_implements',
         // Variables have their own lock protection.
-        'variables'
+        'variables',
+        // Both schema and the theme_registry uses DrupalCacheArray, which sets
+        // the cache entry with a class destructor.
+        'schema:runtime:*',
+        'theme_registry:runtime:*',
       ),
       // Disable stampede protection for cid prefix in 'cache'.
       'cache' => array(
         // I18n uses a class destructor to write the cache.
         'i18n:string:*',
       ),
+      // Disable stampede protection for the contrib cache_rules bin as recent
+      // versions of the rules module provides its own stampede protection.
+      'cache_rules',
     ));
 
     // Support ignoring an entire bin.

--- a/tests/memcache.test
+++ b/tests/memcache.test
@@ -687,6 +687,77 @@ class MemCacheClearCase extends MemcacheTestCase {
 }
 
 /**
+ * Tests memcache stampede protection.
+ */
+class MemCacheStampedeProtection extends MemcacheTestCase {
+
+  public static function getInfo() {
+    return array(
+      'name' => 'Memcache stampede protection',
+      'description' => 'Tests memcache stampede protection.',
+      'group' => 'Memcache',
+    );
+  }
+
+  /**
+   * Tests the opt out functionality of stampede protection using a unit test.
+   */
+  public function testStampedeProtectionIgnoringUnit() {
+    global $conf;
+
+    // Setup a new test bin, to be able to override the used class.
+    $conf['cache_flush_test_bin'] = 0;
+    $conf['cache_class_test_bin'] = 'MockMemCacheDrupal';
+
+    $conf['cache_flush_test_bin_2'] = 0;
+    $conf['cache_class_test_bin_2'] = 'MockMemCacheDrupal';
+
+    // Setup stampede protection.
+    $conf['memcache_stampede_protection'] = TRUE;
+    $conf['memcache_stampede_protection_ignore'] = array(
+      'test_bin',
+      'test_bin_2' => array(
+        'cid_no_prefix',
+        'cid_with_prefix:*',
+      ),
+    );
+
+    // Ensure the mock object is used.
+    /** @var \MockMemCacheDrupal $cache_object_bin */
+    $cache_object_bin = _cache_get_object('test_bin');
+    $this->assertEqual(get_class($cache_object_bin), 'MockMemCacheDrupal');
+    /** @var \MockMemCacheDrupal $cache_object_bin2 */
+    $cache_object_bin2 = _cache_get_object('test_bin_2');
+    $this->assertEqual(get_class($cache_object_bin2), 'MockMemCacheDrupal');
+
+    // Test ignoring of an entire bin.
+    $this->assertFalse($cache_object_bin->stampedeProtected('test_cid'), t('Disable stampede protection for cid contained in a disabled bin.'));
+    $this->assertFalse($cache_object_bin->stampedeProtected('cid_no_prefix'), t('Disable stampede protection for cid without prefix in a disabled bin.'));
+    $this->assertFalse($cache_object_bin->stampedeProtected('cid_with_prefix:example'), t('Disable stampede protection for cid with prefix in a disabled bin.'));
+
+    // Test ignoring of specific CIDs.
+    $this->assertTrue($cache_object_bin2->stampedeProtected('test_cid'), t('Don\'t disable stampede protection for a specific non-matching cid.'));
+    $this->assertFalse($cache_object_bin2->stampedeProtected('cid_no_prefix'), t('Disable stampede protection for a specific cid.'));
+    $this->assertFalse($cache_object_bin2->stampedeProtected('cid_with_prefix:example'), t('Disable stampede protection for a specific cid with disabled prefix.'));
+    $this->assertTrue($cache_object_bin2->stampedeProtected('cid_with_other_prefix:example'), t('Don\'t disable stampede protection for a specific cid with a different prefix.'));
+  }
+
+}
+
+include_once dirname(__DIR__) . '/memcache.inc';
+
+/**
+ * Wraps the MemCacheDrupal class in order to be able to call a protected method.
+ */
+class MockMemCacheDrupal extends MemCacheDrupal {
+
+  public function stampedeProtected($cid) {
+    return parent::stampedeProtected($cid);
+  }
+
+}
+
+/**
  * Test some real world cache scenarios with default modules.
  *
  * Please make sure you've set the proper memcache settings in the settings.php.


### PR DESCRIPTION
Now that we got stampede protection in, we have to update the memcache-remote fork as well.

There was a merge conflict, but it did not really conflicted, just some changes in the same context.
